### PR TITLE
Do conjugate of U matrix for anti-neutrino

### DIFF
--- a/cpupropagator.hpp
+++ b/cpupropagator.hpp
@@ -87,7 +87,17 @@ namespace cudaprob3{
                 throw std::runtime_error("CpuPropagator::calculateProbabilities. production height was not set");
 
             // set neutrino parameters for core physics functions
-            physics::setMixMatrix_host(this->Mix_U.data());
+            switch (type) {
+            case NeutrinoType::Neutrino:
+                physics::setMixMatrix_host(this->Mix_U.data());
+                break;
+            case NeutrinoType::Antineutrino:
+                auto Mix_U_conj = this->Mix_U;
+                for (auto &m : Mix_U_conj) {
+                    m.im = -m.im;
+                }
+                physics::setMixMatrix_host(Mix_U_conj.data());
+            }
             physics::setMassDifferences_host(this->dm.data());
 
             physics::calculate(type, this->cosineList.data(), this->cosineList.size(),

--- a/cudapropagator.cuh
+++ b/cudapropagator.cuh
@@ -200,14 +200,14 @@ namespace cudaprob3{
             // set neutrino parameters for core physics functions for both host and device
             switch (type) {
             case NeutrinoType::Neutrino:
-                physics::setMixMatrix_host(this->Mix_U.data());
+                physics::setMixMatrix(this->Mix_U.data());
                 break;
             case NeutrinoType::Antineutrino:
                 auto Mix_U_conj = this->Mix_U;
                 for (auto &m : Mix_U_conj) {
                     m.im = -m.im;
                 }
-                physics::setMixMatrix_host(Mix_U_conj.data());
+                physics::setMixMatrix(Mix_U_conj.data());
             }
             physics::setMassDifferences(this->dm.data());
 

--- a/cudapropagator.cuh
+++ b/cudapropagator.cuh
@@ -198,7 +198,17 @@ namespace cudaprob3{
             cudaSetDevice(deviceId); CUERR;
 
             // set neutrino parameters for core physics functions for both host and device
-            physics::setMixMatrix(this->Mix_U.data());
+            switch (type) {
+            case NeutrinoType::Neutrino:
+                physics::setMixMatrix_host(this->Mix_U.data());
+                break;
+            case NeutrinoType::Antineutrino:
+                auto Mix_U_conj = this->Mix_U;
+                for (auto &m : Mix_U_conj) {
+                    m.im = -m.im;
+                }
+                physics::setMixMatrix_host(Mix_U_conj.data());
+            }
             physics::setMassDifferences(this->dm.data());
 
             dim3 block(64, 1, 1);


### PR DESCRIPTION
This is for an issue identified when cross checking with result produced by https://github.com/rogerwendell/Prob3plusplus, I've checked the code relating the neutrino type in `physics.hpp` and confirmed the exchange of $U \rightarrow U^*$ was missing for anti-neutrino. This patch does the transform before any propgation happens for antineutrino. 